### PR TITLE
Pass settings directory path to rgc tool

### DIFF
--- a/extra/rgc
+++ b/extra/rgc
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+SETTINGS_DIRECTORY_PATH="$HOME/share/Raygun/AgentSettings"
 
 # Run the rgc command with the selected subcommand
-bash -c "$APM_BIN_DIR/rgc "$@" "
+bash -c "Raygun_SettingsDirectoryPath=\"$SETTINGS_DIRECTORY_PATH\" $APM_BIN_DIR/rgc "$@" "


### PR DESCRIPTION
The CLI tool was looking in the default settings location and not finding a settings file. This caused it to attempt to create the file, which is not allowed on Heroku, so the tool failed.